### PR TITLE
Hiding Sharing menu item if the user doesn't have permission to update the program

### DIFF
--- a/src/components/PRG_List/ProgramItem.js
+++ b/src/components/PRG_List/ProgramItem.js
@@ -69,7 +69,7 @@ const ProgramItem = ({ program, downloadMetadata, shareProgram, deleteProgram, p
                         <Popper reference={ref} placement="bottom-end">
                             <FlyoutMenu>
                                 <MenuItem label="Edit Program" icon={<EditIcon />} onClick={() => { toggle(); setShowProgramForm(true) }} />
-                                <MenuItem label="Sharing Settings" icon={<ShareIcon/>} onClick={()=>{toggle(); shareProgram(program.id)}}/>
+                                {program.access.update && <MenuItem label="Sharing Settings" icon={<ShareIcon/>} onClick={()=>{toggle(); shareProgram(program.id)}}/>}
                                 <MenuItem label="Export JSON Metadata" icon={<DownloadIcon />} onClick={() => { toggle(); downloadMetadata(program.id) }} />
                                 <MenuItem disabled={true} destructive label="Delete Program" icon={<DeleteIcon />} onClick={() => { toggle(); deleteProgram(program.id) }} />
                             </FlyoutMenu>

--- a/src/components/PRG_List/ProgramList.js
+++ b/src/components/PRG_List/ProgramList.js
@@ -45,7 +45,7 @@ const query = {
             let paramsObject = {
                 pageSize,
                 page,
-                fields: ["code", "id", "name", "shortName", "completeEventsExpiryDays", "description", "ignoreOverdueEvents", "skipOffline", "featureType", "minAttributesRequiredToSearch", "displayFrontPageList", "enrollmentDateLabel", "onlyEnrollOnce", "programType", "accessLevel", "sharing", "version", "maxTeiCountToReturn", "selectIncidentDatesInFuture", "incidentDateLabel", "expiryPeriodType", "displayIncidentDate", "selectEnrollmentDatesInFuture", "expiryDays", "useFirstStageDuringRegistration", "relatedProgram", "categoryCombo[id,name]", "trackedEntityType[id,name]", "style", "programTrackedEntityAttributes", "notificationTemplates", "translations", "organisationUnits", "programSections", "attributeValues", "programStages[id,name,programStageSections[*]]"],
+                fields: ["code", "id", "name", "shortName", "completeEventsExpiryDays", "description", "ignoreOverdueEvents", "skipOffline", "featureType", "minAttributesRequiredToSearch", "displayFrontPageList", "enrollmentDateLabel", "onlyEnrollOnce", "programType", "accessLevel", "sharing", "version", "maxTeiCountToReturn", "selectIncidentDatesInFuture", "incidentDateLabel", "expiryPeriodType", "displayIncidentDate", "selectEnrollmentDatesInFuture", "expiryDays", "useFirstStageDuringRegistration", "relatedProgram", "categoryCombo[id,name]", "trackedEntityType[id,name]", "style", "programTrackedEntityAttributes", "notificationTemplates", "translations", "organisationUnits", "programSections", "attributeValues", "programStages[id,name,programStageSections[*]]", "access"],
                 filter: ['withoutRegistration:eq:false']
             }
 

--- a/src/components/Sharing/SharingScreen.js
+++ b/src/components/Sharing/SharingScreen.js
@@ -85,7 +85,7 @@ const SharingScreen = ({ element, id, setSharingProgramId }) => {
     const [deleted, setDeleted] = useState([]);
 
     const { loading, error, data } = useDataQuery(sharingQuery, { variables: { element: element, id: id } });
-    const { loading: entityLoading, data: entities } = useDataQuery(entitiesQuery);
+    const { loading: entityLoading, data: entities, error: entityErrors } = useDataQuery(entitiesQuery);
     const { loading: metadataLoading, data: prgMetaData } = useDataQuery(programMetadata);
     const metadataDM = useDataMutation(metadataMutation);
     const metadataRequest = {
@@ -104,7 +104,7 @@ const SharingScreen = ({ element, id, setSharingProgramId }) => {
     if (loading) return <CircularLoader />
     if (!loading) {
         payload = data.results;
-        if (!entityLoading) {
+        if (!entityLoading && !entityErrors) {
             usersNGroups = availableUserGroups();
         }
     }
@@ -316,7 +316,7 @@ const SharingScreen = ({ element, id, setSharingProgramId }) => {
                             <div style={{ color: 'rgb(129, 129, 129)', paddingBottom: "8px" }}>Add users and user groups</div>
                             <div style={{ display: "flex", flexDirection: "row", alignItems: 'center', flex: "1 1 0"}}>
                                 <div style={{ display: "inline-block", position: "relative", width: "100%", backgroundColor: "white", boxShadow: 'rgb(204,204,204) 2px 2px 2px', padding: "0 16px", marginRight: "16px", height: '3em' }}>
-                                    <input type={"text"} autoComplete={"off"} id={"userNGroup"} onChange={(e) => loadSuggestions(e.target.value)} value={usrGrp || ""} style={{ appearance: "textfield", padding: "0px", position: "relative", border: "none", outline: "none", backgroundColor: 'rgba(0,0,0,0)', color: 'rgba(0,0,0,0.87)', cursor: "inherit", opacity: 1, height: "100%", width: "100%" }} placeholder={"Enter Names"} />
+                                    <input type={"text"} autoComplete={"off"} id={"userNGroup"} onChange={(e) => loadSuggestions(e.target.value)} value={usrGrp || ""} style={{ appearance: "textfield", padding: "0px", position: "relative", border: "none", outline: "none", backgroundColor: 'rgba(0,0,0,0)', color: 'rgba(0,0,0,0.87)', cursor: "inherit", opacity: 1, height: "100%", width: "100%" }} placeholder={"Enter Names"} disabled={entityErrors} />
                                 </div>
                                 {search && <Suggestions usersNGroups={JSON.parse(JSON.stringify(usersNGroups))} keyword={search} setSearch={setSearch} addEntity={addEntity} />}
                                 <div id={'newPermission'} style={{ padding: "auto" }} onClick={() => { toggle(); }}>
@@ -324,8 +324,7 @@ const SharingScreen = ({ element, id, setSharingProgramId }) => {
                                 </div>
                                 {optionOpen && <SharingOptions permission={usrPermission.split("")} reference={document.getElementById('newPermission')} setEntityPermission={setEntityPermission} toggle={toggle} />}
 
-                                <Button onClick={() => assignRole()} variant="outlined">Assign</Button>
-
+                                <Button onClick={() => assignRole()} variant="outlined" disabled={entityErrors}>Assign</Button>
                             </div>
                         </div>
                         {(selectedIndex === 1 || selectedIndex === 2) &&


### PR DESCRIPTION
The sharing menu is hidden if the user doesn't have permission to update the program.
![image](https://user-images.githubusercontent.com/2901204/172751573-ec541dba-162c-4eca-88d0-45ec07da20e4.png)

![image](https://user-images.githubusercontent.com/2901204/172751613-d640024d-2d92-43a4-99d3-9150d725bf7a.png)

Known Issue:
HNQIS users also need permission to read users. for the users to be able to search user and usergroup.
![image](https://user-images.githubusercontent.com/2901204/172751768-a72b6d1b-7d90-40f1-b31d-b4607597572d.png)

If the user doesn't have permission to read users or usergroup, then search and assign functionality are disabled.
![image](https://user-images.githubusercontent.com/2901204/172754982-1046d6f8-6e59-4a89-980c-8d4cbab33fe2.png)

