### PR TITLE
Validation fixes and DataStore migration

### DIFF
--- a/src/components/PRG_List/BackupScreen.js
+++ b/src/components/PRG_List/BackupScreen.js
@@ -3,7 +3,7 @@ import { useDataMutation, useDataQuery } from "@dhis2/app-runtime";
 import CustomMUIDialog from "../UIElements/CustomMUIDialog";
 import CustomMUIDialogTitle from "../UIElements/CustomMUIDialogTitle";
 import { DialogActions, DialogContent, TextField, Button, Box, CircularProgress } from "@mui/material";
-import { NAMESPACE } from "../../configs/Constants";
+import { BACKUPS_NAMESPACE } from "../../configs/Constants";
 import SaveAsIcon from '@mui/icons-material/SaveAs';
 
 const BackupScreen = (props) => {
@@ -15,18 +15,18 @@ const BackupScreen = (props) => {
 
     const queryDataStore = {
         results: {
-            resource: `dataStore/${NAMESPACE}/${props.program.id}`
+            resource: `dataStore/${BACKUPS_NAMESPACE}/${props.program.id}`
         }
     };
 
     const dsCreateMutation = {
-        resource: `dataStore/${NAMESPACE}/${props.program.id}`,
+        resource: `dataStore/${BACKUPS_NAMESPACE}/${props.program.id}`,
         type: 'create',
         data: ({data}) => data
     };
 
     const dsUpdateMutation = {
-        resource: `dataStore/${NAMESPACE}/${props.program.id}`,
+        resource: `dataStore/${BACKUPS_NAMESPACE}/${props.program.id}`,
         type: 'update',
         data: ({data}) => data
     };
@@ -52,6 +52,7 @@ const BackupScreen = (props) => {
     }
 
     const [validationError, setValidationError] = useState(false);
+    const [versionValidationError, setVersionValidationError] = useState(false);
     const [programName, setProgramName] = useState(props.program.name+'_'+  formatDate(new Date(), "_", "_"));
     const [programVersion, setProgramVersion] = useState(props.program.version);
     const [processing, setProcessing] = useState(false);
@@ -94,12 +95,15 @@ const BackupScreen = (props) => {
     const programBackupHandler = () => {
         setProcessing(true);
         const timestamp = formatDate(new Date(), "-", ":");
-        if(nameInput.current.value.trim() === "")
+        if(nameInput.current.value.trim() === "" || versionInput.current.value.trim() === "")
         {
-            setValidationError(true);
+            (nameInput.current.value.trim() === "") ? setValidationError(true) : setValidationError(false) ;
+            (versionInput.current.value.trim() === "") ? setVersionValidationError(true) : setVersionValidationError(false);
+            setProcessing(false);
             return;
         }
         setValidationError(false);
+        setVersionValidationError(false);
         let backup = {
             "id" : new Date().valueOf(),
             "name": nameInput.current.value,
@@ -276,6 +280,8 @@ const BackupScreen = (props) => {
                             inputRef={versionInput}
                             value={programVersion}
                             onChange={e => setProgramVersion(e.target.value)}
+                            helperText={ versionValidationError ? "Please provide the valid Version number" : " "}
+                            error={versionValidationError}
                             />
                         <TextField
                             id="comments"

--- a/src/components/PRG_List/RestoreScreen.js
+++ b/src/components/PRG_List/RestoreScreen.js
@@ -3,16 +3,16 @@ import { useDataMutation, useDataQuery } from "@dhis2/app-runtime";
 import CustomMUIDialog from "../UIElements/CustomMUIDialog";
 import CustomMUIDialogTitle from "../UIElements/CustomMUIDialogTitle";
 import { DialogActions, DialogContent, Alert, Box, CircularProgress, Button, List, Divider } from "@mui/material";
-import { NAMESPACE } from "../../configs/Constants";
+import { BACKUPS_NAMESPACE } from "../../configs/Constants";
 
 import RestoreItem from "./RestoreItem";
 import RestoreOptions from "./RestoreOptions";
-
+``
 const RestoreScreen = (props) => {
 
     const queryDataStore = {
         results: {
-            resource: `dataStore/${NAMESPACE}/${props.program.id}`
+            resource: `dataStore/${BACKUPS_NAMESPACE}/${props.program.id}`
         }
     };
 

--- a/src/configs/Constants.js
+++ b/src/configs/Constants.js
@@ -36,6 +36,7 @@ const H2_REQUIRED = {
 const DATE_FORMAT_OPTIONS = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour:'numeric',minute:'numeric',second:'numeric',hour12:false }
 
 const NAMESPACE = "programconfigapp"
+const BACKUPS_NAMESPACE = `${NAMESPACE}_backups`
 const DATASTORE_PCA_METADATA = "PCAMetadata"
 const DATASTORE_H2_METADATA = "H2Metadata"
 
@@ -122,6 +123,7 @@ export {
     REPORT_DATE_TO_USE,
     METADATA,
     NAMESPACE,
+    BACKUPS_NAMESPACE,
     DATASTORE_PCA_METADATA,
     DATASTORE_H2_METADATA,
     PCA_METADATA_VERSION,


### PR DESCRIPTION
Validation Fixes
- While backing up, user must provide Name and version.

DataStore changes:
- To avoid congestion, the backups are moved from programconfigapp (namespace) to programconfigapp_backups