### PR TITLE
Assign Organisation Unit Popup fixes

### DIFF
--- a/src/components/Org_Units/OunitScreen.js
+++ b/src/components/Org_Units/OunitScreen.js
@@ -118,6 +118,7 @@ const OunitScreen = ({ id, setOrgUnitProgramId, setNotification }) => {
     const [orgUnitTreeRoot, setOrgUnitTreeRoot] = useState([]);
     const [orgUnitFiltered, setOrgUnitFiltered] = useState([]);
     const [orgUnitExpanded, setOrgUnitExpanded] = useState([]);
+    const [filterValue, setFilterValue] = useState('')
 
     const { loading: ouMetadataLoading, data: ouMetadata } =
         useDataQuery(orgUnitsQuery);
@@ -206,9 +207,10 @@ const OunitScreen = ({ id, setOrgUnitProgramId, setNotification }) => {
     };
 
     const doSearch = () => {
-        let filterString = document.getElementById("filterOrgUnitName").value;
+        let filterString = filterRef.current.value;
         if (filterString)
         {
+            setFilterValue(filterString)
             searchOunits.refetch({ filterString: filterString })
                 .then((data) => {
                     if (data?.results) {
@@ -229,7 +231,7 @@ const OunitScreen = ({ id, setOrgUnitProgramId, setNotification }) => {
     }
 
     const resetSearch = () => {
-        document.getElementById("filterOrgUnitName").value = "";
+        setFilterValue("")
         setOrgUnitTreeRoot([]);
         setOrgUnitFiltered([]);
         setOrgUnitExpanded([]);
@@ -366,7 +368,9 @@ const OunitScreen = ({ id, setOrgUnitProgramId, setNotification }) => {
                                         id={"filterOrgUnitName"}
                                         label={ "Filtering Organisation unit by id, code or Name"}
                                         variant="outlined"
-                                        ref={filterRef}
+                                        inputRef={filterRef}
+                                        value={filterValue}
+                                        onChange={(event) => setFilterValue(event.target.value)}
                                         onKeyPress={(event) => {
                                             if (event.key === "Enter") {
                                                 doSearch();


### PR DESCRIPTION
* OrgUnit Filter onChange listener is now replaced with dedicated filter button. User can also do search by pressing enter.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/2901204/194965103-efb2a1c7-3463-4887-9ac8-72f12711e2cc.png">


* now initially expanded is limited to selected orgunit and doesn't expand the children.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/2901204/194965044-597077c0-3463-4694-a69e-0e9b5a45206b.png">
