### PR TITLE
Various Bug fixes related to Sharing settings in Backup / Restore

### DIFF
--- a/src/components/PRG_List/BackupScreen.js
+++ b/src/components/PRG_List/BackupScreen.js
@@ -1,11 +1,25 @@
-import { useState, useRef, useEffect } from "react";
-import { useDataMutation, useDataQuery } from "@dhis2/app-runtime";
+import {useRef, useState} from "react";
+import {useDataMutation, useDataQuery} from "@dhis2/app-runtime";
 import CustomMUIDialog from "../UIElements/CustomMUIDialog";
 import CustomMUIDialogTitle from "../UIElements/CustomMUIDialogTitle";
-import { DialogActions, DialogContent, TextField, Button, Box, CircularProgress } from "@mui/material";
-import { BACKUPS_NAMESPACE } from "../../configs/Constants";
+import {Box, Button, CircularProgress, DialogActions, DialogContent, TextField} from "@mui/material";
+import {
+    ACTION_PLAN_ACTION,
+    ACTION_PLAN_DUE_DATE,
+    ACTION_PLAN_RESPONSIBLE,
+    ASSESSMENT_DATE_ATTRIBUTE,
+    BACKUPS_NAMESPACE,
+    COMPETENCY_ATTRIBUTE,
+    COMPETENCY_CLASS,
+    CRITICAL_STEPS,
+    GLOBAL_SCORE_ATTRIBUTE,
+    HEALTH_AREA_ATTRIBUTE,
+    NON_CRITICAL_STEPS,
+    ORGANISATION_UNIT_ATTRIBUTE
+} from "../../configs/Constants";
 import SaveAsIcon from '@mui/icons-material/SaveAs';
-import { truncateString } from "../../configs/Utils";
+
+import {DeepCopy, truncateString} from "../../configs/Utils";
 
 const BackupScreen = (props) => {
     const programMetadata = {
@@ -62,7 +76,7 @@ const BackupScreen = (props) => {
     let commentInput = useRef();
 
     const { loading: dsLoading, data: dsData } = useDataQuery(queryDataStore);
-    const { loading: loadingMetadata, error: errorMetadata, data: metaData } = useDataQuery(programMetadata);
+    const { loading: loadingMetadata, data: metaData } = useDataQuery(programMetadata);
 
     const dsCreateDM = useDataMutation(dsCreateMutation, {
         onError: (err) => {
@@ -130,10 +144,11 @@ const BackupScreen = (props) => {
             "metadata": processMetadata(metaData.results)
         };
         dsBackups.backups.push(backup);
+        console.log("backup: ", backup.metadata)
         let backupToDatastore = !dsData?.results ? dsCreateRequest : dsUpdateRequest
         backupToDatastore.mutate({ data: dsBackups })
             .then(response => {
-                if (response.status != 'OK') {
+                if (response.status !== 'OK') {
                     props.setNotification({
                         message: `Some errors occured while backing up your Program. Please contact the administrator.`,
                         severity: 'error'
@@ -151,12 +166,18 @@ const BackupScreen = (props) => {
     }
 
     const processMetadata = metadata => {
+        const hnqis_attributes = [ORGANISATION_UNIT_ATTRIBUTE, HEALTH_AREA_ATTRIBUTE, ASSESSMENT_DATE_ATTRIBUTE, GLOBAL_SCORE_ATTRIBUTE, COMPETENCY_ATTRIBUTE]
+        const hnqis_elements = [ACTION_PLAN_RESPONSIBLE, ACTION_PLAN_DUE_DATE, ACTION_PLAN_ACTION, NON_CRITICAL_STEPS, CRITICAL_STEPS, COMPETENCY_CLASS]
         if (metaData) {
             delete metadata.date;
             delete metadata.categories;
             delete metadata.categoryCombos;
             delete metadata.categoryOptions;
             delete metadata.categoryOptionCombos;
+
+            delete metadata.programRuleVariables;
+            delete metadata.programRules;
+            delete metadata.programRuleActions;
 
             metadata.programs?.forEach(program => {
                 delete program.created;
@@ -173,12 +194,6 @@ const BackupScreen = (props) => {
                 });
             });
 
-            metadata.programRuleVariables?.forEach(prv => {
-                delete prv.created;
-                delete prv.lastUpdated;
-                delete prv.lastUpdatedBy;
-            });
-
             metadata.programStageSections?.forEach(stageSection => {
                 delete stageSection.created;
                 delete stageSection.lastUpdated;
@@ -186,7 +201,6 @@ const BackupScreen = (props) => {
             });
 
             metadata.programStages?.forEach(stage => {
-
                 delete stage.created;
                 delete stage.createdBy;
                 delete stage.lastUpdated;
@@ -205,7 +219,7 @@ const BackupScreen = (props) => {
                 delete option.lastUpdated;
             });
 
-            metadata.attributes?.forEach(att => {
+            metadata.attributes?.forEach((att) => {
                 delete att.created;
                 delete att.createdBy;
                 delete att.lastUpdated;
@@ -217,19 +231,7 @@ const BackupScreen = (props) => {
                 delete ptea.lastUpdated;
             });
 
-            metadata.programRules?.forEach(pr => {
-                delete pr.created;
-                delete pr.lastUpdated;
-                delete pr.lastUpdatedBy;
-            });
-
-            metadata.dataElements?.forEach(de => {
-                delete de.created;
-                delete de.createdBy;
-                delete de.lastUpdated;
-                delete de.lastUpdatedBy;
-                delete de.categoryCombo;
-            });
+            metadata.dataElements = DeepCopy(filterComponent(metadata.dataElements, hnqis_elements))
 
             metadata.trackedEntityTypes?.forEach(tet => {
 
@@ -247,22 +249,11 @@ const BackupScreen = (props) => {
 
             });
 
-            metadata.trackedEntityAttributes?.forEach(tea => {
-                delete tea.created;
-                delete tea.createdBy;
-                delete tea.lastUpdated;
-                delete tea.lastUpdatedBy;
-            });
+            metadata.trackedEntityAttributes = DeepCopy(filterComponent(metadata.trackedEntityAttributes, hnqis_attributes))
 
             metadata.programStageDataElements?.forEach(psde => {
                 delete psde.created;
                 delete psde.lastUpdated;
-            });
-
-            metadata.programRuleActions?.forEach(pra => {
-                delete pra.created;
-                delete pra.lastUpdated;
-                delete pra.lastUpdatedBy;
             });
 
             metadata.optionSets?.forEach(optionSet => {
@@ -277,9 +268,25 @@ const BackupScreen = (props) => {
         return null;
     }
 
+    const filterComponent = (elements, filterList) => {
+        let results = []
+        elements?.forEach((element) => {
+            if(!filterList.includes(element.id)) {
+                delete element.created;
+                delete element.createdBy;
+                delete element.lastUpdated;
+                delete element.lastUpdatedBy;
+                delete element?.categoryCombo;
+
+                results.push(element)
+            }
+        })
+        return results;
+    }
+
     return <>
         <CustomMUIDialog open={true} maxWidth="md" fullWidth={true}>
-            {(loadingMetadata || processing) && <Box sx={{ display: 'inline-flex', margin: "50px", display: 'flex' }}><CircularProgress /></Box>}
+            {(loadingMetadata || processing) && <Box sx={{ display: 'inline-flex', margin: "50px" }}><CircularProgress /></Box>}
             {!(loadingMetadata || processing) &&
                 <>
                     <CustomMUIDialogTitle onClose={hideFormHandler} id={"program_backup_dialog_title"}>Create Backup

--- a/src/components/PRG_List/BackupScreen.js
+++ b/src/components/PRG_List/BackupScreen.js
@@ -15,7 +15,8 @@ import {
     GLOBAL_SCORE_ATTRIBUTE,
     HEALTH_AREA_ATTRIBUTE,
     NON_CRITICAL_STEPS,
-    ORGANISATION_UNIT_ATTRIBUTE
+    ORGANISATION_UNIT_ATTRIBUTE,
+    ASSESSMENT_TET
 } from "../../configs/Constants";
 import SaveAsIcon from '@mui/icons-material/SaveAs';
 
@@ -168,6 +169,7 @@ const BackupScreen = (props) => {
     const processMetadata = metadata => {
         const hnqis_attributes = [ORGANISATION_UNIT_ATTRIBUTE, HEALTH_AREA_ATTRIBUTE, ASSESSMENT_DATE_ATTRIBUTE, GLOBAL_SCORE_ATTRIBUTE, COMPETENCY_ATTRIBUTE]
         const hnqis_elements = [ACTION_PLAN_RESPONSIBLE, ACTION_PLAN_DUE_DATE, ACTION_PLAN_ACTION, NON_CRITICAL_STEPS, CRITICAL_STEPS, COMPETENCY_CLASS]
+        const hnqis_tet_exception = [ASSESSMENT_TET]
         if (metaData) {
             delete metadata.date;
             delete metadata.categories;
@@ -233,13 +235,10 @@ const BackupScreen = (props) => {
 
             metadata.dataElements = DeepCopy(filterComponent(metadata.dataElements, hnqis_elements))
 
+            metadata.trackedEntityTypes = DeepCopy(filterComponent(metadata?.trackedEntityTypes, hnqis_tet_exception));
+
+
             metadata.trackedEntityTypes?.forEach(tet => {
-
-                delete tet.created;
-                delete tet.createdBy;
-                delete tet.lastUpdated;
-                delete tet.lastUpdatedBy;
-
                 tet.trackedEntityTypeAttributes?.forEach(tea => {
                     delete tea.created;
                     delete tea.createdBy;

--- a/src/components/PRG_List/BackupScreen.js
+++ b/src/components/PRG_List/BackupScreen.js
@@ -177,10 +177,6 @@ const BackupScreen = (props) => {
             delete metadata.categoryOptions;
             delete metadata.categoryOptionCombos;
 
-            delete metadata.programRuleVariables;
-            delete metadata.programRules;
-            delete metadata.programRuleActions;
-
             metadata.programs?.forEach(program => {
                 delete program.created;
                 delete program.createdBy;

--- a/src/components/PRG_List/RestoreOptions.js
+++ b/src/components/PRG_List/RestoreOptions.js
@@ -36,7 +36,8 @@ import {
     GLOBAL_SCORE_ATTRIBUTE,
     HEALTH_AREA_ATTRIBUTE,
     NON_CRITICAL_STEPS,
-    ORGANISATION_UNIT_ATTRIBUTE
+    ORGANISATION_UNIT_ATTRIBUTE,
+    ASSESSMENT_TET
 } from "../../configs/Constants";
 
 const metadataMutation = {
@@ -158,6 +159,7 @@ const RestoreOptions = props => {
     const restoreHandler = (dryRun) => {
         const hnqis_attributes = [ORGANISATION_UNIT_ATTRIBUTE, HEALTH_AREA_ATTRIBUTE, ASSESSMENT_DATE_ATTRIBUTE, GLOBAL_SCORE_ATTRIBUTE, COMPETENCY_ATTRIBUTE]
         const hnqis_elements = [ACTION_PLAN_RESPONSIBLE, ACTION_PLAN_DUE_DATE, ACTION_PLAN_ACTION, NON_CRITICAL_STEPS, CRITICAL_STEPS, COMPETENCY_CLASS]
+        const hnqis_tet_exception = [ASSESSMENT_TET]
 
         setValidationResult(false);
         setIsLoading(true);
@@ -175,7 +177,7 @@ const RestoreOptions = props => {
             if (checkedState[5]) //Program Tracked Entity Attributes
                 metadataPayload.programTrackedEntityAttributes = DeepCopy(props.backup.metadata.programTrackedEntityAttributes);
             if (checkedState[3]) //TETypes Checked
-                metadataPayload.trackedEntityTypes = DeepCopy(props.backup.metadata.trackedEntityTypes);
+                metadataPayload.trackedEntityTypes = DeepCopy(filterComponent(props.backup.metadata.trackedEntityTypes, hnqis_tet_exception));
             if (checkedState[4]) //Tracked Entity Attributes
                 metadataPayload.trackedEntityAttributes = DeepCopy(filterComponent(props.backup.metadata.trackedEntityAttributes, hnqis_attributes));
             if (checkedState[1]) { //Option Sets

--- a/src/components/PRG_List/RestoreScreen.js
+++ b/src/components/PRG_List/RestoreScreen.js
@@ -1,13 +1,14 @@
-import { useState, useRef, useEffect } from "react";
-import { useDataMutation, useDataQuery } from "@dhis2/app-runtime";
+import {useState} from "react";
+import {useDataQuery} from "@dhis2/app-runtime";
 import CustomMUIDialog from "../UIElements/CustomMUIDialog";
 import CustomMUIDialogTitle from "../UIElements/CustomMUIDialogTitle";
-import { DialogActions, DialogContent, Alert, Box, CircularProgress, Button, List, Divider } from "@mui/material";
-import { BACKUPS_NAMESPACE } from "../../configs/Constants";
+import {Alert, Box, Button, CircularProgress, DialogActions, DialogContent, Divider, List} from "@mui/material";
+import {BACKUPS_NAMESPACE} from "../../configs/Constants";
 
 import RestoreItem from "./RestoreItem";
 import RestoreOptions from "./RestoreOptions";
-import { truncateString } from "../../configs/Utils";
+import {truncateString} from "../../configs/Utils";
+
 ``
 const RestoreScreen = (props) => {
 
@@ -36,7 +37,7 @@ const RestoreScreen = (props) => {
 
     return <>
                 <CustomMUIDialog open={true} maxWidth="md" fullWidth={true}>
-                    {loading && <Box sx={{ display: 'inline-flex', margin: "50px", display: 'flex' }}><CircularProgress /></Box>}
+                    {loading && <Box sx={{ display: 'inline-flex', margin: "50px" }}><CircularProgress /></Box>}
                     {!loading &&
                         <>
                             <CustomMUIDialogTitle onClose={hideFormHandler} id={"program_restore_dialog_title"}>


### PR DESCRIPTION
1. Fixed: while restoring, the import summary related to dry run was crashing
2. Remove some key HNQIS data elements, tracked Entity Attributes and tracked entity types from backing up and restoring.
3. fixed sharing settings keep/overwrite while restoring backups
4. Added: Program Indicator restore option
5. Validation: Restore buttons are disabled if the user doesn't select Program before restoring
![image](https://user-images.githubusercontent.com/2901204/201489127-4db9846d-6bc8-431d-a003-aeb0647e1203.png)
