### PR TITLE
Org Unit Tree was not loading

### DIFF
--- a/src/components/PRG_List/H2Setting.js
+++ b/src/components/PRG_List/H2Setting.js
@@ -229,7 +229,6 @@ const H2Setting = forwardRef((props, ref) => {
                 selectedOrgUnits.length === 0
             )
                 response = false;
-            console.log("selected Org Units: ", selectedOrgUnits);
             validationErrors.healthArea =
                 healthArea === "" ? "This field is required" : undefined;
             validationErrors.ouTableRow =
@@ -242,7 +241,6 @@ const H2Setting = forwardRef((props, ref) => {
                     : undefined;
             validationErrors.aggregationType =
                 aggregationType === "" ? "This field is required" : undefined;
-            console.log("Validation Errors: ", validationErrors);
             return response;
         },
 

--- a/src/components/PRG_List/H2Setting.js
+++ b/src/components/PRG_List/H2Setting.js
@@ -153,14 +153,13 @@ const H2Setting = forwardRef((props, ref) => {
                 );
                 setOrgUnitPathSelected([data.result.path]);
                 setOULevels(ouLevels);
+                setSelectedOrgUnits([props.pcaMetadata?.ouRoot]);
             }
         };
     
         const fetchOrgUnits = async () => {
             try {
                 if (!ouMetadataLoading && props.pcaMetadata?.ouRoot) {
-                    setSelectedOrgUnits([props.pcaMetadata?.ouRoot]);
-    
                     checkAndResetValues(props.pcaMetadata?.ouLevelTable, setOUTableRow);
                     checkAndResetValues(props.pcaMetadata?.ouLevelMap, setOUMapPolygon);
     
@@ -169,6 +168,7 @@ const H2Setting = forwardRef((props, ref) => {
                     ouTreeNLevelInit();
                 }
             } catch (error) {
+                setSelectedOrgUnits([]);
                 setOrgUnitPathSelected([]);
                 setOULevels(ouMetadata);
             }
@@ -229,6 +229,7 @@ const H2Setting = forwardRef((props, ref) => {
                 selectedOrgUnits.length === 0
             )
                 response = false;
+            console.log("selected Org Units: ", selectedOrgUnits);
             validationErrors.healthArea =
                 healthArea === "" ? "This field is required" : undefined;
             validationErrors.ouTableRow =
@@ -241,6 +242,7 @@ const H2Setting = forwardRef((props, ref) => {
                     : undefined;
             validationErrors.aggregationType =
                 aggregationType === "" ? "This field is required" : undefined;
+            console.log("Validation Errors: ", validationErrors);
             return response;
         },
 

--- a/src/components/PRG_List/H2Setting.js
+++ b/src/components/PRG_List/H2Setting.js
@@ -139,31 +139,36 @@ const H2Setting = forwardRef((props, ref) => {
     }
 
     useEffect(() => {
-        if (!ouMetadataLoading) {
-            if (props.pcaMetadata?.ouRoot) {
-                setSelectedOrgUnits([props.pcaMetadata?.ouRoot])
-                ouLevelRefetch({ id: props.pcaMetadata?.ouRoot }).then(data => {
-                    console.log(data)
+        const fetchOrgUnits = async () => {
+            try {
+                if (!ouMetadataLoading && props.pcaMetadata?.ouRoot) {
+                    setSelectedOrgUnits([props.pcaMetadata?.ouRoot]);
+                    
+                    const data = await ouLevelRefetch({ id: props.pcaMetadata?.ouRoot });
+                    console.log(data);
+                    
                     if (typeof data.result !== "undefined") {
                         let ouLevels = ouMetadata.orgUnitLevels?.organisationUnitLevels.filter(ol => ol.level >= data.result.level);
-                        setOrgUnitPathSelected([data.result.path])
+                        setOrgUnitPathSelected([data.result.path]);
                         setOULevels(ouLevels);
                     }
-                }).catch(err => {
-                    console.log(err);
-                });
-            }
-            else {
-                ouTreeNLevelInit()
+                } else {
+                    ouTreeNLevelInit();
+                }
+            } catch (error) {
+                setOrgUnitPathSelected([]);
+                setOULevels(ouMetadata);
+                console.log("ouLevelLoading: ", ouLevelLoading);
             }
         }
+        fetchOrgUnits();
     }, [ouMetadata]);
 
     useEffect(() => {
-        if (!ouLevelLoading && orgUnitPathSelected.length > 0) {
+        if ((!ouLevelLoading && orgUnitPathSelected.length > 0) || noOULevelFound) {
             ouTreeNLevelInit(ouMetadata)
         }
-    }, [orgUnitPathSelected])
+    }, [orgUnitPathSelected, noOULevelFound])
 
     let ouTreeNLevelInit = () => {
         setOrgUnitTreeRoot([...ouMetadata.userOrgUnits?.organisationUnits.map(ou => ou.id)]);

--- a/src/components/PRG_List/H2Setting.js
+++ b/src/components/PRG_List/H2Setting.js
@@ -139,30 +139,43 @@ const H2Setting = forwardRef((props, ref) => {
     }
 
     useEffect(() => {
+        const checkAndResetValues = (key, setter) => {
+            if (!ouMetadata.orgUnitLevels.organisationUnitLevels.some(olevel => olevel.id === key)) {
+                setter("");
+            }
+        };
+    
+        const fetchDataAndSetState = async () => {
+            const data = await ouLevelRefetch({ id: props.pcaMetadata?.ouRoot });
+            if (data.result) {
+                const ouLevels = ouMetadata.orgUnitLevels?.organisationUnitLevels.filter(
+                    ol => ol.level >= data.result.level
+                );
+                setOrgUnitPathSelected([data.result.path]);
+                setOULevels(ouLevels);
+            }
+        };
+    
         const fetchOrgUnits = async () => {
             try {
                 if (!ouMetadataLoading && props.pcaMetadata?.ouRoot) {
                     setSelectedOrgUnits([props.pcaMetadata?.ouRoot]);
-                    
-                    const data = await ouLevelRefetch({ id: props.pcaMetadata?.ouRoot });
-                    console.log(data);
-                    
-                    if (typeof data.result !== "undefined") {
-                        let ouLevels = ouMetadata.orgUnitLevels?.organisationUnitLevels.filter(ol => ol.level >= data.result.level);
-                        setOrgUnitPathSelected([data.result.path]);
-                        setOULevels(ouLevels);
-                    }
+    
+                    checkAndResetValues(props.pcaMetadata?.ouLevelTable, setOUTableRow);
+                    checkAndResetValues(props.pcaMetadata?.ouLevelMap, setOUMapPolygon);
+    
+                    await fetchDataAndSetState();
                 } else {
                     ouTreeNLevelInit();
                 }
             } catch (error) {
                 setOrgUnitPathSelected([]);
                 setOULevels(ouMetadata);
-                console.log("ouLevelLoading: ", ouLevelLoading);
             }
-        }
+        };
+    
         fetchOrgUnits();
-    }, [ouMetadata]);
+    }, [ouMetadata]);    
 
     useEffect(() => {
         if ((!ouLevelLoading && orgUnitPathSelected.length > 0) || noOULevelFound) {


### PR DESCRIPTION
Problem Statement
-------------------
For HNQIS program, 
1. Organisation unit tree was not loading when trying to edit an HNQIS program with missing selected org unit id.
2. Organisation Unit levels were also not loading if missing level id

Solution
-----------
If the HNQIS Program has missing org unit id or level id, then as a fall back, organisation unit tree would be generated without selecting any organisation units and all the levels would be deselected

Screenshot
-------------
![image](https://github.com/psi-org/Program-Config-App/assets/2901204/eb83837d-9739-4640-82fb-a77273ec7967)
